### PR TITLE
fix: Add missing decimals field in util function return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Fix return type for `toErc20InstancesPerNamedNetwork`: Missing `decimals` field added.
+
 # 1.1.0
 
 - Add utils for transforming query results to structures that can be easily serialized the JSON format used by the Mangrove smart contract repos.

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,3 +41,11 @@ export type Erc20NetworkInstance = {
   address: Address;
   default?: boolean;
 };
+
+export type Erc20Instance = {
+  symbol: string;
+  decimals: number;
+  id: string;
+  address: string;
+  default: boolean;
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@
  * Utilities used by the Mangrove smart contract repos.
  */
 
-import { Erc20, Erc20Id, Role, UniqueId } from "./types";
+import { Erc20, Erc20Id, Erc20Instance, Role, UniqueId } from "./types";
 
 /** Network names used in Mangrove smart contract repos.
  *
@@ -111,20 +111,8 @@ export function toNamedAddressesPerNamedNetwork(
  */
 export function toErc20InstancesPerNamedNetwork(
   erc20s: Record<Erc20Id, Erc20>,
-): Record<
-  string,
-  { symbol: string; id: string; address: string; default: boolean }[]
-> {
-  const instancesPerNamedNetwork: Record<
-    string,
-    {
-      symbol: string;
-      decimals: number;
-      id: string;
-      address: string;
-      default: boolean;
-    }[]
-  > = {};
+): Record<string, Erc20Instance[]> {
+  const instancesPerNamedNetwork: Record<string, Erc20Instance[]> = {};
 
   for (const [, erc20] of Object.entries(erc20s)) {
     for (const [networkId, networkInstances] of Object.entries(


### PR DESCRIPTION
The `toErc20InstancesPerNamedNetwork` returns token instances that include a `decimals` field, but this was not included in the return type. This PR adds the field and extracts the type to avoid the issue in the future.