### PR TITLE
feat: Add Blast network name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Add Blast network name (chain ID 238)
+
 # 1.1.4
 
 - Add Blast Sepolia Multicall2 address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 - Add Blast network name (chain ID 238)
+- Add `chainIdToNetworkName` function to convert a chain IDs to the network names used in Mangrove smart contract repos.
 
 # 1.1.4
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,16 @@ export const mangroveNetworkNames = {
 } as Record<string, string>;
 
 /**
+ * Convert a chain ID to a network name.
+ * @param chainId Chain ID.
+ * @returns Network name or `undefined` if the chain ID is not known.
+ * @see mangroveNetworkNames
+ */
+export function chainIdToNetworkName(chainId: number): string | undefined {
+  return mangroveNetworkNames["" + chainId];
+}
+
+/**
  * Transform role groups as returned by most of the query methods to a structure that can
  * be easily serialized the JSON format used by the Mangrove smart contract repos when
  * reading addresses:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,7 @@ export const mangroveNetworkNames = {
   "97": "bnbt",
   "100": "xdai",
   "137": "matic",
+  "238": "blast",
   "420": "optimism-goerli",
   "42161": "arbitrum",
   "80001": "maticmum",

--- a/test/unit/utils.unit.test.ts
+++ b/test/unit/utils.unit.test.ts
@@ -4,9 +4,20 @@ import { expect } from "chai";
 import {
   toNamedAddressesPerNamedNetwork,
   toErc20InstancesPerNamedNetwork,
+  chainIdToNetworkName,
 } from "../../src/utils";
 
 describe("utils.ts", () => {
+  describe("chainIdToNetworkName", () => {
+    it("should return undefined for unknown chain ID", () => {
+      expect(chainIdToNetworkName(123)).to.be.undefined;
+    });
+
+    it("should return network name for known chain ID", () => {
+      expect(chainIdToNetworkName(1)).to.equal("mainnet");
+    });
+  });
+
   describe("toNamedAddressesPerNamedNetwork", () => {
     it("should return empty object for empty input", () => {
       expect(toNamedAddressesPerNamedNetwork()).to.deep.equal({});


### PR DESCRIPTION
Also, adds a `chainIdToNetworkName` that makes it easier to convert from chain ID to network name.